### PR TITLE
Fix Background

### DIFF
--- a/sketch/sketch.go
+++ b/sketch/sketch.go
@@ -40,7 +40,7 @@ func NewSketch(source image.Image, userParams UserParams) *Sketch {
 
 	canvas := gg.NewContext(s.DestWidth, s.DestHeight)
 	canvas.SetColor(color.Black)
-	canvas.DrawRectangle(0, 0, float64(s.sourceWidth), float64(s.sourceHeight))
+	canvas.DrawRectangle(0, 0, float64(s.DestWidth), float64(s.DestHeight))
 	canvas.FillPreserve()
 
 	s.source = source


### PR DESCRIPTION
## Issue
In situations where the source image is smaller than the output image, the first step draws a black box in the top left corner, leaving the rest of the canvas transparent. Depending on the number of iterations, and the alpha settings, this can cause a distinct black box to show in the top left corner.

I have some examples of what I mean. These examples are set up with some extreme and impractical values in order to clearly demonstrate the issue

### Before Fix
![image](https://user-images.githubusercontent.com/18297490/107058853-1daae000-67a3-11eb-92f3-10a6e7558c0f.png)

### After Fix
![image](https://user-images.githubusercontent.com/18297490/107058883-28fe0b80-67a3-11eb-9a09-a17355b7224d.png)

## Solution
This PR draws the background as the same size as the output file, rather than the source image.

This issue is also present in the code in the book.

P.S. Thanks for writing the book :) I've had a lot of fun playing with this code, and the history and theory stuff was interesting to read.